### PR TITLE
feat: Enhance Inventory Display with Manifest Data

### DIFF
--- a/guardian-definitivo/src/Data/ManifestService.cs
+++ b/guardian-definitivo/src/Data/ManifestService.cs
@@ -266,6 +266,28 @@ namespace GuardianDefinitivo.Data
 
         // Puedes añadir más métodos de consulta para otras definiciones aquí (e.g., DestinyObjectiveDefinition, DestinyActivityDefinition, etc.)
 
+        public async Task<DestinyDamageTypeDefinition?> GetDamageTypeDefinitionAsync(uint damageTypeHash)
+        {
+            return await GetDefinitionAsync<DestinyDamageTypeDefinition>(damageTypeHash, "DestinyDamageTypeDefinition");
+        }
+
+        public async Task<DestinyClassDefinition?> GetClassDefinitionAsync(uint classHash)
+        {
+            return await GetDefinitionAsync<DestinyClassDefinition>(classHash, "DestinyClassDefinition");
+        }
+
+        public async Task<DestinyRaceDefinition?> GetRaceDefinitionAsync(uint raceHash)
+        {
+            return await GetDefinitionAsync<DestinyRaceDefinition>(raceHash, "DestinyRaceDefinition");
+        }
+
+        public async Task<DestinyGenderDefinition?> GetGenderDefinitionAsync(uint genderHash)
+        {
+            return await GetDefinitionAsync<DestinyGenderDefinition>(genderHash, "DestinyGenderDefinition");
+        }
+
+        // TODO: Consider adding methods for DestinySocketTypeDefinition, DestinyStatGroupDefinition, etc. if needed.
+
         public void Dispose()
         {
             // SqliteConnection se dispone en GetDefinitionAsync gracias al `await using`.

--- a/guardian-definitivo/src/Models/Destiny/Definitions/DestinyClassDefinition.cs
+++ b/guardian-definitivo/src/Models/Destiny/Definitions/DestinyClassDefinition.cs
@@ -1,0 +1,29 @@
+// guardian-definitivo/src/Models/Destiny/Definitions/DestinyClassDefinition.cs
+using System.Text.Json.Serialization;
+using GuardianDefinitivo.Models.Destiny.Definitions.Common;
+
+namespace GuardianDefinitivo.Models.Destiny.Definitions
+{
+    /// <summary>
+    /// Defines a Character Class in Destiny 2. These are types of characters you can play, like Titan, Hunter, and Warlock.
+    /// Sourced from: https://bungie-net.github.io/multi/schema_Destiny-Definitions-DestinyClassDefinition.html#schema_Destiny-Definitions-DestinyClassDefinition
+    /// </summary>
+    public class DestinyClassDefinition : DestinyDefinition
+    {
+        [JsonPropertyName("displayProperties")]
+        public DestinyDisplayPropertiesDefinition? DisplayProperties { get; set; }
+
+        /// <summary>
+        /// In Destiny 1, we added a convenience Enumeration for referring to classes.
+        /// We've kept it, though mostly for posterity. This is the enum value for this definition.
+        /// </summary>
+        [JsonPropertyName("classType")]
+        public int ClassType { get; set; } // Enum: DestinyClass (e.g. Titan = 0, Hunter = 1, Warlock = 2, Unknown = 3)
+
+        [JsonPropertyName("genderedClassNames")]
+        public Dictionary<string, string>? GenderedClassNames { get; set; } // Keyed by gender hash (string "0" or "1" etc.) or by gender enum name
+
+        [JsonPropertyName("genderedClassNamesByGenderHash")]
+        public Dictionary<uint, string>? GenderedClassNamesByGenderHash { get; set; } // Keyed by DestinyGenderDefinition hash
+    }
+}

--- a/guardian-definitivo/src/Models/Destiny/Definitions/DestinyDamageTypeDefinition.cs
+++ b/guardian-definitivo/src/Models/Destiny/Definitions/DestinyDamageTypeDefinition.cs
@@ -1,0 +1,40 @@
+// guardian-definitivo/src/Models/Destiny/Definitions/DestinyDamageTypeDefinition.cs
+using System.Text.Json.Serialization;
+using GuardianDefinitivo.Models.Destiny.Definitions.Common;
+
+namespace GuardianDefinitivo.Models.Destiny.Definitions
+{
+    /// <summary>
+    /// All damage types that are possible in the game are defined here, along with localized info and icons as needed.
+    /// Sourced from: https://bungie-net.github.io/multi/schema_Destiny-Definitions-DestinyDamageTypeDefinition.html#schema_Destiny-Definitions-DestinyDamageTypeDefinition
+    /// </summary>
+    public class DestinyDamageTypeDefinition : DestinyDefinition
+    {
+        [JsonPropertyName("displayProperties")]
+        public DestinyDisplayPropertiesDefinition? DisplayProperties { get; set; }
+
+        /// <summary>
+        /// A color associated with the damage type.
+        /// </summary>
+        [JsonPropertyName("color")]
+        public DestinyColorDefinition? Color { get; set; } // Using the existing DestinyColorDefinition from InventoryItemDefinition for now
+
+        /// <summary>
+        /// The icon that appears on television screens and interfaces.
+        /// </summary>
+        [JsonPropertyName("transparentIconPath")]
+        public string? TransparentIconPath { get; set; }
+
+        /// <summary>
+        /// If TRUE, the game shows this damage type's icon. Otherwise, it doesn't.
+        /// </summary>
+        [JsonPropertyName("showIcon")]
+        public bool ShowIcon { get; set; }
+
+        /// <summary>
+        /// We have an enumeration for damage types for quick reference. This is the current definition's damage type enum value.
+        /// </summary>
+        [JsonPropertyName("enumValue")]
+        public int EnumValue { get; set; } // Enum: DamageType
+    }
+}

--- a/guardian-definitivo/src/Models/Destiny/Definitions/DestinyGenderDefinition.cs
+++ b/guardian-definitivo/src/Models/Destiny/Definitions/DestinyGenderDefinition.cs
@@ -1,0 +1,24 @@
+// guardian-definitivo/src/Models/Destiny/Definitions/DestinyGenderDefinition.cs
+using System.Text.Json.Serialization;
+using GuardianDefinitivo.Models.Destiny.Definitions.Common;
+
+namespace GuardianDefinitivo.Models.Destiny.Definitions
+{
+    /// <summary>
+    /// Gender is a social construct, and as such we have definitions for Genders. Right now there are only two,
+    /// but we may expand this sometime in the future.
+    /// Sourced from: https://bungie-net.github.io/multi/schema_Destiny-Definitions-DestinyGenderDefinition.html#schema_Destiny-Definitions-DestinyGenderDefinition
+    /// </summary>
+    public class DestinyGenderDefinition : DestinyDefinition
+    {
+        [JsonPropertyName("displayProperties")]
+        public DestinyDisplayPropertiesDefinition? DisplayProperties { get; set; }
+
+        /// <summary>
+        /// This is a quick reference enumeration for all of the currently defined Genders.
+        /// We use this solely to map the Gender values stored in the database to a conceptual values.
+        /// </summary>
+        [JsonPropertyName("genderType")]
+        public int GenderType { get; set; } // Enum: DestinyGender
+    }
+}

--- a/guardian-definitivo/src/Models/Destiny/Definitions/DestinyInventoryItemDefinition.cs
+++ b/guardian-definitivo/src/Models/Destiny/Definitions/DestinyInventoryItemDefinition.cs
@@ -70,8 +70,35 @@ namespace GuardianDefinitivo.Models.Destiny.Definitions
         [JsonPropertyName("inventory")]
         public DestinyItemInventoryBlockDefinition? Inventory { get; set; }
 
+        [JsonPropertyName("stats")]
+        public Items.DestinyItemStatBlockDefinition? Stats { get; set; }
+
+        [JsonPropertyName("equippingBlock")]
+        public Items.DestinyItemEquippingBlockDefinition? EquippingBlock { get; set; }
+
+        [JsonPropertyName("perks")]
+        public List<Items.DestinyItemPerkEntryDefinition>? Perks { get; set; }
+
+        [JsonPropertyName("sockets")]
+        public Sockets.DestinyItemSocketBlockDefinition? Sockets { get; set; }
+
+        [JsonPropertyName("itemSubType")]
+        public int ItemSubType { get; set; } // Enum: DestinyItemSubType
+
+        [JsonPropertyName("classType")]
+        public int ClassType { get; set; } // Enum: DestinyClass
+
+        [JsonPropertyName("defaultDamageType")]
+        public int DefaultDamageType { get; set; } // Enum: DamageType, 0 if not applicable
+
+        [JsonPropertyName("defaultDamageTypeHash")]
+        public uint? DefaultDamageTypeHash { get; set; } // Hash for DestinyDamageTypeDefinition
+
+        [JsonPropertyName("damageTypeHashes")]
+        public List<uint>? DamageTypeHashes { get; set; } // Hashes for DestinyDamageTypeDefinition
+
         // Other potentially useful fields to add later:
-        // itemSubType, classType, equippable, defaultDamageType, investmentStats, perks, loreHash, etc.
+        // loreHash, investmentStats (DestinyItemInvestmentStatDefinition) etc.
 
         // Standard DestinyDefinition properties
         // These are inherited from the base class DestinyDefinition

--- a/guardian-definitivo/src/Models/Destiny/Definitions/DestinyRaceDefinition.cs
+++ b/guardian-definitivo/src/Models/Destiny/Definitions/DestinyRaceDefinition.cs
@@ -1,0 +1,34 @@
+// guardian-definitivo/src/Models/Destiny/Definitions/DestinyRaceDefinition.cs
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GuardianDefinitivo.Models.Destiny.Definitions.Common;
+
+namespace GuardianDefinitivo.Models.Destiny.Definitions
+{
+    /// <summary>
+    /// In Destiny, "Races" are really more like "Species". Sort of. I mean, are the Awoken a separate species from humans? I'm not sure.
+    /// But either way, they're defined here. You'll see Exo, Awoken, and Human as examples of these.
+    /// Sourced from: https://bungie-net.github.io/multi/schema_Destiny-Definitions-DestinyRaceDefinition.html#schema_Destiny-Definitions-DestinyRaceDefinition
+    /// </summary>
+    public class DestinyRaceDefinition : DestinyDefinition
+    {
+        [JsonPropertyName("displayProperties")]
+        public DestinyDisplayPropertiesDefinition? DisplayProperties { get; set; }
+
+        /// <summary>
+        /// An enumeration defining the existing, known Races in Destiny.
+        /// </summary>
+        [JsonPropertyName("raceType")]
+        public int RaceType { get; set; } // Enum: DestinyRace
+
+        /// <summary>
+        /// A localized string referring to the singular form of the Race's name when referred to in gendered form.
+        /// Keyed by the DestinyGenderDefinition hash.
+        /// </summary>
+        [JsonPropertyName("genderedRaceNames")]
+        public Dictionary<uint, string>? GenderedRaceNames { get; set; } // Key is GenderHash
+
+        [JsonPropertyName("genderedRaceNamesByGenderHash")] // Redundant with above but sometimes present
+        public Dictionary<string, string>? GenderedRaceNamesByGenderHash { get; set; } // Key is GenderHash as string
+    }
+}

--- a/guardian-definitivo/src/Models/Destiny/Definitions/Items/DestinyItemEquippingBlockDefinition.cs
+++ b/guardian-definitivo/src/Models/Destiny/Definitions/Items/DestinyItemEquippingBlockDefinition.cs
@@ -1,0 +1,56 @@
+// guardian-definitivo/src/Models/Destiny/Definitions/Items/DestinyItemEquippingBlockDefinition.cs
+using System.Text.Json.Serialization;
+
+namespace GuardianDefinitivo.Models.Destiny.Definitions.Items
+{
+    /// <summary>
+    /// Items that can be equipped define this block. It contains information about the slot where the item is equipped, and other customizability options.
+    /// Sourced from: https://bungie-net.github.io/multi/schema_Destiny-Definitions-DestinyEquippingBlockDefinition.html#schema_Destiny-Definitions-DestinyEquippingBlockDefinition
+    /// </summary>
+    public class DestinyItemEquippingBlockDefinition
+    {
+        /// <summary>
+        /// If the item is part of a gearset, this is a reference to that gearset item.
+        /// </summary>
+        [JsonPropertyName("gearsetItemHash")]
+        public uint? GearsetItemHash { get; set; }
+
+        /// <summary>
+        /// If defined, this is the label used to check if the item has other items of the same type already equipped.
+        /// For instance, when you aren't allowed to equip more than one Exotic Weapon, that's because all exotic weapons have identical uniqueLabels and the game checks the number of items with that label already equipped.
+        /// </summary>
+        [JsonPropertyName("uniqueLabel")]
+        public string? UniqueLabel { get; set; }
+
+        /// <summary>
+        /// The hash of that unique label. Does not point to a specific definition.
+        /// </summary>
+        [JsonPropertyName("uniqueLabelHash")]
+        public uint UniqueLabelHash { get; set; }
+
+        /// <summary>
+        /// An equipped item's slot type. This is an enum indicating what kind of equipment slot it goes into.
+        /// </summary>
+        [JsonPropertyName("equipmentSlotTypeHash")]
+        public uint EquipmentSlotTypeHash { get; set; }
+
+        /// <summary>
+        /// The attributes of the item when equipped.
+        /// </summary>
+        [JsonPropertyName("attributes")]
+        public int Attributes { get; set; } // Enum: EquippingItemBlockAttributes
+
+        /// <summary>
+        /// Ammo type used by a weapon is resolved by looking up the DestinyAmmoTypeDefinition for this hash.
+        /// </summary>
+        [JsonPropertyName("ammoType")]
+        public int AmmoType { get; set; } // Enum: DestinyAmmunitionType
+
+        /// <summary>
+        /// These are custom attributes on the equippability of the item.
+        /// For now, this can only be "equipmolesto" which only tells you if the item has stats that are affected by the overall stat rolls of every equipped item.
+        /// </summary>
+        [JsonPropertyName("displayStrings")]
+        public List<string>? DisplayStrings { get; set; }
+    }
+}

--- a/guardian-definitivo/src/Models/Destiny/Definitions/Items/DestinyItemPerkEntryDefinition.cs
+++ b/guardian-definitivo/src/Models/Destiny/Definitions/Items/DestinyItemPerkEntryDefinition.cs
@@ -1,0 +1,31 @@
+// guardian-definitivo/src/Models/Destiny/Definitions/Items/DestinyItemPerkEntryDefinition.cs
+using System.Text.Json.Serialization;
+
+namespace GuardianDefinitivo.Models.Destiny.Definitions.Items
+{
+    /// <summary>
+    /// An item can have perks. This is a detailed definition of a perk on a specific item.
+    /// Sourced from: https://bungie-net.github.io/multi/schema_Destiny-Definitions-DestinyItemPerkEntryDefinition.html#schema_Destiny-Definitions-DestinyItemPerkEntryDefinition
+    /// </summary>
+    public class DestinyItemPerkEntryDefinition
+    {
+        /// <summary>
+        /// A hash that can be used to look up the DestinySandboxPerkDefinition if it exists.
+        /// (NOTE: This is a DestinySandboxPerkDefinition, not a DestinyInventoryItemDefinition of a perk item. Perks are not items.)
+        /// </summary>
+        [JsonPropertyName("perkHash")]
+        public uint PerkHash { get; set; }
+
+        /// <summary>
+        /// If this perk is not active, this is the string to show for why it's not providing its benefits.
+        /// </summary>
+        [JsonPropertyName("perkVisibility")]
+        public int PerkVisibility { get; set; } // Enum: ItemPerkVisibility
+
+        /// <summary>
+        /// If this perk is related to a specific requirement, the requirement hash will be provided here.
+        /// </summary>
+        [JsonPropertyName("requirementDisplayString")]
+        public string? RequirementDisplayString { get; set; }
+    }
+}

--- a/guardian-definitivo/src/Models/Destiny/Definitions/Items/DestinyItemStatBlockDefinition.cs
+++ b/guardian-definitivo/src/Models/Destiny/Definitions/Items/DestinyItemStatBlockDefinition.cs
@@ -1,0 +1,82 @@
+// guardian-definitivo/src/Models/Destiny/Definitions/Items/DestinyItemStatBlockDefinition.cs
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GuardianDefinitivo.Models.Destiny.Definitions.Items
+{
+    /// <summary>
+    /// Information about the item's stats.
+    /// Sourced from: https://bungie-net.github.io/multi/schema_Destiny-Definitions-DestinyItemStatBlockDefinition.html#schema_Destiny-Definitions-DestinyItemStatBlockDefinition
+    /// </summary>
+    public class DestinyItemStatBlockDefinition
+    {
+        /// <summary>
+        /// If true, the game won't show the "primary" stat on this item when you inspect it.
+        /// </summary>
+        [JsonPropertyName("disablePrimaryStatDisplay")]
+        public bool DisablePrimaryStatDisplay { get; set; }
+
+        /// <summary>
+        /// If the item's stats are meant to be modified by a DestinyStatGroupDefinition, this will be the identifier for that definition.
+        /// </summary>
+        [JsonPropertyName("statGroupHash")]
+        public uint? StatGroupHash { get; set; }
+
+        /// <summary>
+        /// If you are looking for pre-calculated values for the stats on a weapon, this is where they are stored.
+        /// Corresponds to the primary stats that you see in-game.
+        /// </summary>
+        [JsonPropertyName("stats")]
+        public Dictionary<uint, DestinyInventoryItemStatDefinition>? Stats { get; set; } // Key is statHash
+
+        /// <summary>
+        /// A quick and lazy way to determine whether any stat other than the primary stat has a value.
+        /// </summary>
+        [JsonPropertyName("hasDisplayableStats")]
+        public bool HasDisplayableStats { get; set; }
+
+        /// <summary>
+        /// This stat is determined primarily by the item's quality. This is the hash of the DestinyStatDefinition that holds the quality stat.
+        /// </summary>
+        [JsonPropertyName("primaryBaseStatHash")]
+        public uint PrimaryBaseStatHash { get; set; }
+    }
+
+    /// <summary>
+    /// Defines a specific stat that an Item Instance can have.
+    /// This is the definition for stats that are intrinsic to an item, not those that are coming from plugs.
+    /// Sourced from: https://bungie-net.github.io/multi/schema_Destiny-Definitions-DestinyInventoryItemStatDefinition.html#schema_Destiny-Definitions-DestinyInventoryItemStatDefinition
+    /// </summary>
+    public class DestinyInventoryItemStatDefinition
+    {
+        /// <summary>
+        /// The hash for the DestinyStatDefinition representing this stat.
+        /// </summary>
+        [JsonPropertyName("statHash")]
+        public uint StatHash { get; set; }
+
+        /// <summary>
+        /// This value represents the stat value assuming the minimum possible roll, zero masterwork, and no mods.
+        /// </summary>
+        [JsonPropertyName("value")]
+        public int Value { get; set; }
+
+        /// <summary>
+        /// The minimum possible value for this stat.
+        /// </summary>
+        [JsonPropertyName("minimum")]
+        public int Minimum { get; set; }
+
+        /// <summary>
+        /// The maximum possible value for this stat.
+        /// </summary>
+        [JsonPropertyName("maximum")]
+        public int Maximum { get; set; }
+
+        /// <summary>
+        /// If the stat is on an item that can be masterworked, this is the maximum value the stat can achieve, including the masterwork benefit.
+        /// </summary>
+        [JsonPropertyName("displayMaximum")]
+        public int? DisplayMaximum { get; set; }
+    }
+}

--- a/guardian-definitivo/src/Models/Destiny/Definitions/Sockets/DestinyItemSocketBlockDefinition.cs
+++ b/guardian-definitivo/src/Models/Destiny/Definitions/Sockets/DestinyItemSocketBlockDefinition.cs
@@ -1,0 +1,39 @@
+// guardian-definitivo/src/Models/Destiny/Definitions/Sockets/DestinyItemSocketBlockDefinition.cs
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GuardianDefinitivo.Models.Destiny.Definitions.Sockets
+{
+    /// <summary>
+    /// If defined, the item has sockets. This block allows you to determine the Point Power granted by a socket entry.
+    /// Sourced from: https://bungie-net.github.io/multi/schema_Destiny-Definitions-DestinyItemSocketBlockDefinition.html#schema_Destiny-Definitions-DestinyItemSocketBlockDefinition
+    /// </summary>
+    public class DestinyItemSocketBlockDefinition
+    {
+        /// <summary>
+        /// This was supposed to be a string that would give per-item details about the socket block.
+        /// It is now a stub andندہ should be ignored.
+        /// </summary>
+        [JsonPropertyName("detail")]
+        public string? Detail { get; set; }
+
+        /// <summary>
+        /// Each non-intrinsic (or mutable) socket on an item is defined here. Check inside for more info.
+        /// </summary>
+        [JsonPropertyName("socketEntries")]
+        public List<DestinyItemSocketEntryDefinition>? SocketEntries { get; set; }
+
+        /// <summary>
+        /// Each intrinsic (or immutable/permanent) socket on an item is defined here, along with the plug that is permanently affixed to the socket.
+        /// </summary>
+        [JsonPropertyName("intrinsicSockets")]
+        public List<DestinyItemIntrinsicSocketEntryDefinition>? IntrinsicSockets { get; set; }
+
+
+        /// <summary>
+        /// A convenience property, that refers to the sockets in the "sockets" property, pre-grouped by category and ordered correctly according to BNet data.
+        /// </summary>
+        [JsonPropertyName("socketCategories")]
+        public List<DestinyItemSocketCategoryDefinition>? SocketCategories { get; set; }
+    }
+}

--- a/guardian-definitivo/src/Models/Destiny/Definitions/Sockets/DestinyItemSocketCategoryDefinition.cs
+++ b/guardian-definitivo/src/Models/Destiny/Definitions/Sockets/DestinyItemSocketCategoryDefinition.cs
@@ -1,0 +1,27 @@
+// guardian-definitivo/src/Models/Destiny/Definitions/Sockets/DestinyItemSocketCategoryDefinition.cs
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GuardianDefinitivo.Models.Destiny.Definitions.Sockets
+{
+    /// <summary>
+    /// Sockets are grouped into categories in the UI. These categories have conceptual meaning:
+    /// For instance, UI Category "Weapon Perks" are sockets that choose one perk in a columm.
+    /// UI Category "Weapon Mods" are sockets that allow you to insert mods into a weapon.
+    /// Sourced from: https://bungie-net.github.io/multi/schema_Destiny-Definitions-DestinyItemSocketCategoryDefinition.html#schema_Destiny-Definitions-DestinyItemSocketCategoryDefinition
+    /// </summary>
+    public class DestinyItemSocketCategoryDefinition
+    {
+        /// <summary>
+        /// The hash for the DestinySocketCategoryDefinition.
+        /// </summary>
+        [JsonPropertyName("socketCategoryHash")]
+        public uint SocketCategoryHash { get; set; }
+
+        /// <summary>
+        /// A list of socket indexes that are part of this category.
+        /// </summary>
+        [JsonPropertyName("socketIndexes")]
+        public List<int>? SocketIndexes { get; set; }
+    }
+}

--- a/guardian-definitivo/src/Models/Destiny/Definitions/Sockets/DestinyItemSocketEntryDefinition.cs
+++ b/guardian-definitivo/src/Models/Destiny/Definitions/Sockets/DestinyItemSocketEntryDefinition.cs
@@ -1,0 +1,104 @@
+// guardian-definitivo/src/Models/Destiny/Definitions/Sockets/DestinyItemSocketEntryDefinition.cs
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GuardianDefinitivo.Models.Destiny.Definitions.Sockets
+{
+    /// <summary>
+    /// The static definition for item sockets. This will determine information like the type of socket,
+    /// the appearance of the socket, and sometimes restrictions on what can be inserted in the socket.
+    /// Sourced from: https://bungie-net.github.io/multi/schema_Destiny-Definitions-DestinyItemSocketEntryDefinition.html#schema_Destiny-Definitions-DestinyItemSocketEntryDefinition
+    /// </summary>
+    public class DestinyItemSocketEntryDefinition
+    {
+        /// <summary>
+        /// All sockets have a type, and this is the hash identifier for this particular type. Use it to look up DestinySocketTypeDefinition.
+        /// </summary>
+        [JsonPropertyName("socketTypeHash")]
+        public uint SocketTypeHash { get; set; }
+
+        /// <summary>
+        /// If a valid hash, this is the hash identifier for the DestinyInventoryItemDefinition representing the single item that can be inserted into this socket.
+        /// Otherwise, this field is null.
+        /// </summary>
+        [JsonPropertyName("singleInitialItemHash")]
+        public uint SingleInitialItemHash { get; set; } // Note: API says "if a valid hash", implies it can be 0 if not applicable.
+
+        /// <summary>
+        /// Identifies all items that can be inserted into this socket.
+        /// </summary>
+        [JsonPropertyName("reusablePlugItems")]
+        public List<DestinyItemSocketEntryPlugItemDefinition>? ReusablePlugItems { get; set; }
+
+        /// <summary>
+        /// If this is true, then the socket is visible in the item's detail screen.
+        /// </summary>
+        [JsonPropertyName("plugSources")]
+        public int PlugSources { get; set; } // Enum: SocketPlugSources
+
+        /// <summary>
+        /// If this is true, then the socket is visible in the item's detail screen.
+        /// OBSOLETE: use plugSources instead.
+        /// </summary>
+        [JsonPropertyName("isVisible")]
+        public bool IsVisible_OBSOLETE { get; set; }
+
+
+        /// <summary>
+        /// This field is an immutable list of plug item hashes that are valid for this socket. Only if displayProperties permits it will this socket allow any other plugs to be inserted.
+        /// </summary>
+        [JsonPropertyName("reusablePlugSetHash")]
+        public uint? ReusablePlugSetHash { get; set; }
+
+        /// <summary>
+        /// This field is an immutable list of plug item hashes that are valid for this socket. Only if displayProperties permits it will this socket allow any other plugs to be inserted.
+        /// </summary>
+        [JsonPropertyName("randomizedPlugSetHash")]
+        public uint? RandomizedPlugSetHash { get; set; }
+
+        /// <summary>
+        /// If true, then this socket is related to an intrinsic perk. See the plugSources property for the type of intrinsic perk.
+        /// </summary>
+        [JsonPropertyName("defaultVisible")]
+        public bool DefaultVisible { get; set; }
+    }
+
+    /// <summary>
+    /// The definition of a known, reusable plug that can be inserted into a socket.
+    /// Sourced from: https://bungie-net.github.io/multi/schema_Destiny-Definitions-DestinyItemSocketEntryPlugItemDefinition.html#schema_Destiny-Definitions-DestinyItemSocketEntryPlugItemDefinition
+    /// </summary>
+    public class DestinyItemSocketEntryPlugItemDefinition
+    {
+        /// <summary>
+        /// The hash identifier of a DestinyInventoryItemDefinition representing the plug that can be inserted.
+        /// </summary>
+        [JsonPropertyName("plugItemHash")]
+        public uint PlugItemHash { get; set; }
+    }
+
+    /// <summary>
+    /// Defines a socket that has a plug associated with it intrinsically.
+    /// This is useful for situations where the weapon needs to have a visual plug/perk defined on it, but you don't want it to be socketable.
+    /// Sourced from: https://bungie-net.github.io/multi/schema_Destiny-Definitions-DestinyItemIntrinsicSocketEntryDefinition.html#schema_Destiny-Definitions-DestinyItemIntrinsicSocketEntryDefinition
+    /// </summary>
+    public class DestinyItemIntrinsicSocketEntryDefinition
+    {
+        /// <summary>
+        /// Indicates the plug that is intrinsically inserted into this socket.
+        /// </summary>
+        [JsonPropertyName("plugItemHash")]
+        public uint PlugItemHash { get; set; }
+
+        /// <summary>
+        /// Indicates the type of this intrinsic socket.
+        /// </summary>
+        [JsonPropertyName("socketTypeHash")]
+        public uint SocketTypeHash { get; set; }
+
+        /// <summary>
+        /// If true, then this socket is visible in the item's detail screen.
+        /// </summary>
+        [JsonPropertyName("defaultVisible")]
+        public bool DefaultVisible { get; set; }
+    }
+}

--- a/guardian-definitivo/src/UI/Helpers/DisplayHelper.cs
+++ b/guardian-definitivo/src/UI/Helpers/DisplayHelper.cs
@@ -1,0 +1,173 @@
+// guardian-definitivo/src/UI/Helpers/DisplayHelper.cs
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GuardianDefinitivo.Data; // For ManifestService
+using GuardianDefinitivo.Models.Destiny.Definitions;
+using GuardianDefinitivo.Models.Destiny.Entities.Items;
+using GuardianDefinitivo.Models.Destiny.Components.Items; // For instance components
+
+namespace GuardianDefinitivo.UI.Helpers
+{
+    public static class DisplayHelper
+    {
+        public static async Task<string> FormatItemDetailsAsync(
+            ManifestService manifestService,
+            DestinyItemComponent item,
+            DestinyInventoryItemDefinition itemDef,
+            DestinyItemInstanceComponent? instanceData,
+            DestinyItemStatsComponent? instanceStats, // Stats from item instance
+            DestinyItemPerksComponent? instancePerks, // Perks from item instance/sockets
+            DestinyItemSocketsComponent? instanceSockets // Sockets from item instance
+            // Potentially add more components like DestinyItemReusablePlugsComponent if needed
+        )
+        {
+            if (itemDef.DisplayProperties == null)
+            {
+                return $"Item Hash: {item.ItemHash} (Sin propiedades de visualización)";
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"--- {itemDef.DisplayProperties.Name} ({itemDef.ItemTypeDisplayName}) ---");
+
+            if (!string.IsNullOrEmpty(itemDef.DisplayProperties.Description))
+            {
+                sb.AppendLine($"  \"{itemDef.DisplayProperties.Description}\"");
+            }
+
+            if (itemDef.Inventory != null)
+            {
+                sb.AppendLine($"  Tier: {itemDef.Inventory.TierTypeName ?? "Desconocido"}");
+            }
+
+            if (instanceData != null)
+            {
+                sb.AppendLine($"  Luz: {instanceData.ItemLevel}");
+                if (instanceData.DamageTypeHash.HasValue)
+                {
+                    var damageTypeDef = await manifestService.GetDamageTypeDefinitionAsync(instanceData.DamageTypeHash.Value);
+                    sb.AppendLine($"  Tipo de Daño (Instancia): {damageTypeDef?.DisplayProperties?.Name ?? instanceData.DamageTypeHash.Value.ToString()}");
+                }
+            }
+            else if (itemDef.DefaultDamageTypeHash.HasValue) // Para items no instanciados con tipo de daño (ej. shaders con elemento)
+            {
+                 var damageTypeDef = await manifestService.GetDamageTypeDefinitionAsync(itemDef.DefaultDamageTypeHash.Value);
+                 sb.AppendLine($"  Tipo de Daño (Defecto): {damageTypeDef?.DisplayProperties?.Name ?? itemDef.DefaultDamageTypeHash.Value.ToString()}");
+            }
+
+
+            if (itemDef.EquippingBlock != null && itemDef.EquippingBlock.AmmoType > 0)
+            {
+                // Para obtener el nombre del tipo de munición, necesitaríamos otra definición (DestinyAmmunitionTypeDefinition)
+                // Por ahora, mostraremos el valor numérico del enum DestinyAmmunitionType.
+                sb.AppendLine($"  Tipo de Munición: {(Models.Destiny.DestinyAmmunitionType)itemDef.EquippingBlock.AmmoType}");
+            }
+
+            // Mostrar Stats
+            // Combinar stats base de la definición con stats de instancia
+            var combinedStats = new Dictionary<uint, Models.Destiny.Stats.DestinyStat>();
+
+            // Stats base de la definición del item (DestinyInventoryItemStatDefinition)
+            if (itemDef.Stats?.Stats != null)
+            {
+                foreach (var statDefPair in itemDef.Stats.Stats)
+                {
+                    combinedStats[statDefPair.Key] = new Models.Destiny.Stats.DestinyStat { StatHash = statDefPair.Key, Value = statDefPair.Value.Value };
+                }
+            }
+            // Stats de la instancia del item (DestinyStat)
+            if (instanceStats?.Stats != null)
+            {
+                foreach (var instStatPair in instanceStats.Stats)
+                {
+                    // Sobrescribir o añadir, ya que las de instancia son las "finales" para ese roll
+                    combinedStats[instStatPair.Key] = instStatPair.Value;
+                }
+            }
+
+            if (combinedStats.Any())
+            {
+                sb.AppendLine("  Stats:");
+                foreach (var statPair in combinedStats.OrderBy(s => GetStatDisplayOrder(s.Key))) // Ordenar por una lógica predefinida
+                {
+                    var statDef = await manifestService.GetStatDefinitionAsync(statPair.Key);
+                    if (statDef?.DisplayProperties != null)
+                    {
+                        sb.AppendLine($"    - {statDef.DisplayProperties.Name}: {statPair.Value.Value}");
+                    }
+                }
+            }
+
+            // Mostrar Perks (Intrínsecos de la definición y de la instancia)
+            var allPerkHashes = new HashSet<uint>();
+            if (itemDef.Perks != null)
+            {
+                foreach(var perkEntry in itemDef.Perks) allPerkHashes.Add(perkEntry.PerkHash);
+            }
+            if (instancePerks?.Perks != null)
+            {
+                foreach(var perkRef in instancePerks.Perks) allPerkHashes.Add(perkRef.PerkHash);
+            }
+            // Podríamos también obtener perks de los sockets si están equipados, pero eso es más complejo por ahora.
+
+            if (allPerkHashes.Any())
+            {
+                sb.AppendLine("  Perks Clave:");
+                foreach (uint perkHash in allPerkHashes.Take(5)) // Mostrar los primeros N perks
+                {
+                    var perkDef = await manifestService.GetPerkDefinitionAsync(perkHash);
+                    if (perkDef?.DisplayProperties != null && perkDef.IsDisplayable)
+                    {
+                        sb.AppendLine($"    * {perkDef.DisplayProperties.Name}");
+                    }
+                }
+            }
+
+            sb.AppendLine(); // Línea extra al final
+            return sb.ToString();
+        }
+
+        // Helper para ordenar stats (ejemplo básico)
+        private static int GetStatDisplayOrder(uint statHash)
+        {
+            // Estos son hashes comunes, se pueden encontrar en la documentación o explorando el manifest
+            switch (statHash)
+            {
+                // Weapon Stats
+                case 4043523819: return 1; // Impact
+                case 1240592695: return 2; // Range
+                case 155624089:  return 3; // Stability
+                case 943549884:  return 4; // Handling
+                case 4188031367: return 5; // Reload Speed
+                case 2715839340: return 6; // Rounds Per Minute
+                case 3555269338: return 7; // Magazine
+                case 2523465841: return 8; // Aim Assistance
+                case 2762071195: return 9; // Recoil Direction
+                case 3022301683: return 10; // Zoom
+                // Armor Stats (Mobility, Resilience, Recovery, Discipline, Intellect, Strength)
+                case 2996146975: return 100; // Mobility
+                case 3927672834: return 101; // Resilience
+                case 1943323491: return 102; // Recovery
+                case 1735777505: return 103; // Discipline
+                case 144602215:  return 104; // Intellect
+                case 4244567218: return 105; // Strength
+                default: return 999; // Otros al final
+            }
+        }
+    }
+}
+
+// Enum para DestinyAmmunitionType (basado en Destiny.DestinyAmmunitionType)
+// Debería ir en un archivo de Enums si se usa más extensamente.
+namespace GuardianDefinitivo.Models.Destiny
+{
+    public enum DestinyAmmunitionType
+    {
+        None = 0,
+        Primary = 1,
+        Special = 2,
+        Heavy = 3,
+        Unknown = 4
+    }
+}


### PR DESCRIPTION
- Extended DestinyInventoryItemDefinition and related models (EquippingBlock, StatBlock, PerkEntry, Sockets, DamageType, Class, Race, Gender) to include more fields from the Manifest.
- Added new query methods to ManifestService for DamageType, Class, Race, and Gender definitions.
- Created DisplayHelper class with FormatItemDetailsAsync method to generate detailed, human-readable string representations of items using Manifest definitions and instance data.
- Updated Program.cs to:
    - Fetch necessary item components (Instances, Stats, Perks, Sockets).
    - Display richer character information (Class, Race, Gender names).
    - Utilize DisplayHelper to show detailed information for equipped items, character inventory items, and vault items, including name, type, light level, tier, description, damage type, ammo type, stats, and key perks.